### PR TITLE
Add article analysis pipeline and service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
 # AITools
+
+This repository demonstrates a lightweight analytics pipeline that converts
+stored news articles into actionable investment intelligence.  The core
+components are written in Python and are intentionally rule-based so that they
+can run in constrained environments without model dependencies.
+
+## Features
+
+- **Article analysis:** `backend/analysis.py` ingests stored articles, scores
+  them for keyword intensity, sentiment, and social buzz, and extracts ticker
+  symbols through pattern matching and optional metadata.
+- **Equity impact ranking:** Aggregated scores reveal which equities are most
+  affected by recent coverage and assigns an investment suggestion (buy, hold,
+  sell, or watch).
+- **Service helpers:** `backend/service.py` exposes the top ranked articles and
+  tickers as serialised JSON that can back an API endpoint, job, or CLI tool.
+
+## Usage
+
+1. Install dependencies (only the Python standard library is required).
+2. Populate `data/articles.json` with the articles you want to analyse.  A small
+   illustrative dataset is included.
+3. Run the service helper to generate the ranked output:
+
+   ```bash
+   python -m backend.service
+   ```
+
+   The command prints a JSON payload describing the top 10 articles and tickers
+   along with their suggested investment actions.
+
+## Extending the pipeline
+
+- Replace the keyword weights or sentiment lexicon in `ArticleAnalyzer` to tune
+  the scoring for your domain.
+- Wire `generate_ranked_results` into a web framework (Flask, FastAPI, etc.) to
+  serve the JSON payload over HTTP.
+- Swap the rule-based sentiment classifier with a machine-learning model for
+  higher fidelity scoring.
+
+## Repository structure
+
+```
+backend/
+  __init__.py
+  analysis.py        # Core analysis and ranking pipeline
+  service.py         # JSON/CLI service helpers
+
+data/
+  articles.json      # Example data set used for testing
+```

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,17 @@
+"""Backend package providing article analysis utilities."""
+
+from .analysis import (
+    AnalysisSummary,
+    Article,
+    ArticleAnalysis,
+    ArticleAnalyzer,
+    TickerImpact,
+)
+
+__all__ = [
+    "AnalysisSummary",
+    "Article",
+    "ArticleAnalysis",
+    "ArticleAnalyzer",
+    "TickerImpact",
+]

--- a/backend/analysis.py
+++ b/backend/analysis.py
@@ -1,0 +1,442 @@
+"""Utilities for analysing financial news articles.
+
+This module provides lightweight natural language processing routines to score
+articles for their relevance and potential market impact.  The pipeline is
+composed of three stages:
+
+* Keyword and buzz metrics quantify how intensely an article discusses topics
+  that tend to move markets.
+* A rule-based sentiment analyser classifies the tone of the article using a
+  configurable lexicon of positive and negative finance terms.
+* Extracted ticker symbols are aggregated so that the equities most affected by
+  the news can be ranked and paired with an investment suggestion.
+
+The goal of the implementation is to offer a transparent baseline that can be
+swapped out for more sophisticated services (machine-learning APIs, knowledge
+bases, etc.) while still being fully deterministic and suitable for unit tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import math
+import re
+from collections import Counter, defaultdict
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+
+_TICKER_STOPWORDS = {
+    "CEO",
+    "CFO",
+    "GDP",
+    "SEC",
+    "FOMC",
+    "FED",
+    "EPS",
+    "ETF",
+    "IPO",
+    "USA",
+    "UK",
+    "EU",
+    "USD",
+    "NYSE",
+    "NASDAQ",
+    "Dow",
+}
+
+
+@dataclass
+class Article:
+    """Represents an article pulled from storage or an external API."""
+
+    id: str
+    title: str
+    content: str
+    tickers: List[str] = field(default_factory=list)
+    keywords: Optional[Sequence[str]] = None
+    social_shares: int = 0
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Article":
+        """Create an :class:`Article` instance from a mapping.
+
+        The loader is intentionally forgiving and will normalise common field
+        names provided by external APIs.
+        """
+
+        # Normalise identifier and content fields.
+        identifier = str(data.get("id") or data.get("article_id") or data.get("uuid") or "")
+        title = str(data.get("title") or data.get("headline") or "").strip()
+        content = str(data.get("content") or data.get("body") or data.get("summary") or "").strip()
+
+        # Accumulate tickers from the payload if explicitly provided.
+        ticker_values: Sequence[str] = data.get("tickers") or data.get("symbols") or []  # type: ignore[assignment]
+        metadata = {key: value for key, value in data.items() if key not in {"id", "article_id", "uuid", "title", "headline", "content", "body", "summary", "tickers", "symbols", "keywords", "social_shares"}}
+
+        # Some providers embed social metrics under a nested object.
+        social_shares = int(
+            data.get("social_shares")
+            or (data.get("social") or {}).get("shares")  # type: ignore[call-arg]
+            or (data.get("engagement") or {}).get("shares")  # type: ignore[call-arg]
+            or 0
+        )
+
+        keywords = data.get("keywords")  # type: ignore[assignment]
+
+        tickers: List[str] = []
+        for value in ticker_values:
+            if isinstance(value, str):
+                ticker = value.strip().upper()
+                if ticker and ticker not in tickers:
+                    tickers.append(ticker)
+
+        return cls(
+            id=identifier or data.get("url", ""),
+            title=title,
+            content=content,
+            tickers=tickers,
+            keywords=keywords,
+            social_shares=social_shares,
+            metadata=metadata,
+        )
+
+
+@dataclass
+class ArticleAnalysis:
+    """Detailed metrics for a single analysed article."""
+
+    article: Article
+    keyword_hits: Dict[str, int]
+    keyword_score: float
+    sentiment_score: float
+    social_score: float
+    impact_score: float
+    tickers: List[str]
+    recommended_action: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "article_id": self.article.id,
+            "title": self.article.title,
+            "tickers": self.tickers,
+            "sentiment_score": round(self.sentiment_score, 3),
+            "keyword_score": round(self.keyword_score, 3),
+            "social_score": round(self.social_score, 3),
+            "impact_score": round(self.impact_score, 3),
+            "keyword_hits": self.keyword_hits,
+            "recommended_action": self.recommended_action,
+        }
+
+
+@dataclass
+class TickerImpact:
+    """Aggregated impact metrics for a ticker symbol."""
+
+    ticker: str
+    impact_score: float
+    avg_sentiment: float
+    avg_social: float
+    article_ids: List[str]
+    recommended_action: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ticker": self.ticker,
+            "impact_score": round(self.impact_score, 3),
+            "avg_sentiment": round(self.avg_sentiment, 3),
+            "avg_social": round(self.avg_social, 3),
+            "articles": self.article_ids,
+            "recommended_action": self.recommended_action,
+        }
+
+
+@dataclass
+class AnalysisSummary:
+    """Container for all analysis artefacts."""
+
+    articles: List[ArticleAnalysis]
+    tickers: List[TickerImpact]
+    generated_at: datetime = field(default_factory=datetime.utcnow)
+
+    def top_articles(self, top_n: int = 10) -> List[ArticleAnalysis]:
+        return sorted(self.articles, key=lambda result: result.impact_score, reverse=True)[:top_n]
+
+    def top_tickers(self, top_n: int = 10) -> List[TickerImpact]:
+        return sorted(self.tickers, key=lambda ticker: abs(ticker.impact_score), reverse=True)[:top_n]
+
+    def to_serializable(self, top_n: int = 10) -> Dict[str, Any]:
+        return {
+            "generated_at": self.generated_at.isoformat() + "Z",
+            "top_articles": [result.to_dict() for result in self.top_articles(top_n)],
+            "top_tickers": [ticker.to_dict() for ticker in self.top_tickers(top_n)],
+        }
+
+
+class ArticleAnalyzer:
+    """Scores articles and produces investment suggestions.
+
+    The analyser is intentionally rule-based to keep the implementation
+    transparent and reproducible.  It can be extended by injecting custom
+    keyword weights or sentiment lexicons.
+    """
+
+    keyword_weights: MutableMapping[str, float]
+    positive_words: Sequence[str]
+    negative_words: Sequence[str]
+    keyword_reference_score: float
+    social_reference: float
+
+    def __init__(
+        self,
+        keyword_weights: Optional[Mapping[str, float]] = None,
+        positive_words: Optional[Sequence[str]] = None,
+        negative_words: Optional[Sequence[str]] = None,
+        keyword_reference_score: float = 6.0,
+        social_reference: float = 5000.0,
+    ) -> None:
+        self.keyword_weights = {
+            "growth": 1.5,
+            "earnings": 2.0,
+            "revenue": 1.7,
+            "guidance": 1.4,
+            "merger": 2.5,
+            "acquisition": 2.5,
+            "regulation": 2.0,
+            "downgrade": 2.2,
+            "upgrade": 2.2,
+            "lawsuit": 2.3,
+            "partnership": 1.6,
+            "buyback": 2.0,
+        }
+        if keyword_weights:
+            for keyword, weight in keyword_weights.items():
+                if weight > 0:
+                    self.keyword_weights[keyword.lower()] = float(weight)
+
+        self.positive_words = [
+            "beat",
+            "beats",
+            "bullish",
+            "exceed",
+            "exceeds",
+            "gain",
+            "gains",
+            "growth",
+            "improve",
+            "improves",
+            "optimistic",
+            "outperform",
+            "positive",
+            "profit",
+            "rally",
+            "record",
+            "resilient",
+            "surge",
+            "upgrade",
+            "upside",
+            "win",
+        ]
+        if positive_words:
+            self.positive_words = list({*self.positive_words, *[word.lower() for word in positive_words]})
+
+        self.negative_words = [
+            "bearish",
+            "cut",
+            "cuts",
+            "decline",
+            "downgrade",
+            "drop",
+            "drops",
+            "fall",
+            "falls",
+            "lawsuit",
+            "loss",
+            "miss",
+            "misses",
+            "negative",
+            "plunge",
+            "regulation",
+            "slump",
+            "slowdown",
+            "volatility",
+            "warning",
+        ]
+        if negative_words:
+            self.negative_words = list({*self.negative_words, *[word.lower() for word in negative_words]})
+
+        self.keyword_reference_score = keyword_reference_score
+        self.social_reference = max(social_reference, 1.0)
+
+        self._keyword_pattern = re.compile(r"\b([a-zA-Z][a-zA-Z\-]+)\b")
+        self._ticker_cash_pattern = re.compile(r"\$([A-Z]{1,5})\b")
+        self._ticker_upper_pattern = re.compile(r"\b([A-Z]{2,5})\b")
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def analyze_articles(self, articles: Iterable[Article]) -> AnalysisSummary:
+        article_results: List[ArticleAnalysis] = []
+        ticker_accumulator: Dict[str, Dict[str, Any]] = defaultdict(lambda: {
+            "impact_sum": 0.0,
+            "sentiment_sum": 0.0,
+            "social_sum": 0.0,
+            "articles": [],
+        })
+
+        for article in articles:
+            analysis = self._analyze_single_article(article)
+            article_results.append(analysis)
+
+            for ticker in analysis.tickers:
+                bucket = ticker_accumulator[ticker]
+                bucket["impact_sum"] += analysis.impact_score
+                bucket["sentiment_sum"] += analysis.sentiment_score
+                bucket["social_sum"] += analysis.social_score
+                bucket["articles"].append(analysis.article.id)
+
+        ticker_impacts: List[TickerImpact] = []
+        for ticker, data in ticker_accumulator.items():
+            article_count = max(len(data["articles"]), 1)
+            avg_sentiment = data["sentiment_sum"] / article_count
+            avg_social = data["social_sum"] / article_count
+            impact_score = data["impact_sum"] / article_count
+            action = self._action_from_score(avg_sentiment, impact_score, avg_social)
+            ticker_impacts.append(
+                TickerImpact(
+                    ticker=ticker,
+                    impact_score=impact_score,
+                    avg_sentiment=avg_sentiment,
+                    avg_social=avg_social,
+                    article_ids=list(data["articles"]),
+                    recommended_action=action,
+                )
+            )
+
+        return AnalysisSummary(articles=article_results, tickers=ticker_impacts)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _analyze_single_article(self, article: Article) -> ArticleAnalysis:
+        tickers = self._extract_tickers(article)
+        keyword_score, keyword_hits = self._score_keywords(article)
+        sentiment_score = self._score_sentiment(article.content)
+        social_score = self._score_social(article)
+        impact_score = self._combine_scores(sentiment_score, keyword_score, social_score)
+        action = self._action_from_score(sentiment_score, impact_score, social_score)
+
+        return ArticleAnalysis(
+            article=article,
+            keyword_hits=keyword_hits,
+            keyword_score=keyword_score,
+            sentiment_score=sentiment_score,
+            social_score=social_score,
+            impact_score=impact_score,
+            tickers=tickers,
+            recommended_action=action,
+        )
+
+    def _extract_tickers(self, article: Article) -> List[str]:
+        tickers = {ticker for ticker in article.tickers if ticker and ticker.isupper()}
+
+        # Extract cashtag tickers like $AAPL
+        for match in self._ticker_cash_pattern.finditer(article.content):
+            tickers.add(match.group(1))
+
+        # Extract uppercase words while filtering known stop words.
+        for match in self._ticker_upper_pattern.finditer(article.content):
+            candidate = match.group(1)
+            if candidate in _TICKER_STOPWORDS:
+                continue
+            if 1 < len(candidate) <= 5:
+                tickers.add(candidate)
+
+        # Metadata may contain a preferred ticker symbol.
+        metadata_ticker = article.metadata.get("primary_ticker")
+        if isinstance(metadata_ticker, str):
+            tickers.add(metadata_ticker.upper())
+
+        return sorted(tickers)
+
+    def _score_keywords(self, article: Article) -> Tuple[float, Dict[str, int]]:
+        if article.keywords:
+            keywords = [keyword.lower() for keyword in article.keywords]
+        else:
+            keywords = list(self.keyword_weights.keys())
+
+        tokens = [token.lower() for token in self._keyword_pattern.findall(article.content.lower())]
+        frequencies = Counter(tokens)
+
+        keyword_hits: Dict[str, int] = {}
+        weighted_sum = 0.0
+        for keyword in keywords:
+            count = frequencies.get(keyword, 0)
+            if count <= 0:
+                continue
+            keyword_hits[keyword] = count
+            weight = self.keyword_weights.get(keyword, 1.0)
+            weighted_sum += weight * count
+
+        # Normalise into [0, 1]
+        keyword_score = min(weighted_sum / max(self.keyword_reference_score, 1.0), 1.0)
+        return keyword_score, keyword_hits
+
+    def _score_sentiment(self, text: str) -> float:
+        if not text:
+            return 0.0
+
+        tokens = [token.lower() for token in self._keyword_pattern.findall(text.lower())]
+        positive = sum(1 for token in tokens if token in self.positive_words)
+        negative = sum(1 for token in tokens if token in self.negative_words)
+        total = positive + negative
+        if total == 0:
+            return 0.0
+        score = (positive - negative) / total
+        # Clamp to [-1, 1]
+        return max(min(score, 1.0), -1.0)
+
+    def _score_social(self, article: Article) -> float:
+        shares = article.social_shares
+        # Allow additional social metrics from metadata (likes, comments, etc.)
+        social_meta = article.metadata.get("social") or {}
+        if isinstance(social_meta, Mapping):
+            shares += int(social_meta.get("likes") or 0)
+            shares += 2 * int(social_meta.get("comments") or 0)
+        engagement_meta = article.metadata.get("engagement") or {}
+        if isinstance(engagement_meta, Mapping):
+            shares += int(engagement_meta.get("retweets") or 0)
+            shares += int(engagement_meta.get("mentions") or 0)
+
+        if shares <= 0:
+            return 0.0
+
+        normalized = math.log1p(shares) / math.log1p(self.social_reference)
+        return max(0.0, min(normalized, 1.0))
+
+    def _combine_scores(self, sentiment: float, keyword: float, social: float) -> float:
+        # Sentiment drives direction while keyword intensity and social buzz
+        # modulate conviction.
+        influence = 0.6 + 0.25 * keyword + 0.15 * social
+        score = sentiment * influence
+        return max(min(score, 1.0), -1.0)
+
+    def _action_from_score(self, sentiment: float, impact: float, social: float) -> str:
+        intensity = abs(impact)
+        if impact >= 0.6:
+            return "buy"
+        if impact >= 0.25:
+            return "hold"
+        if impact <= -0.6:
+            return "sell"
+        if impact <= -0.25:
+            return "watch"
+        # For low conviction scenarios fall back to social buzz and sentiment
+        if intensity < 0.15:
+            return "watch"
+        if sentiment > 0.1 and social >= 0.3:
+            return "hold"
+        if sentiment < -0.1 and social >= 0.3:
+            return "sell"
+        return "watch"

--- a/backend/service.py
+++ b/backend/service.py
@@ -1,0 +1,77 @@
+"""Service helpers that expose article analysis results.
+
+The module keeps the service layer deliberately light-weight so that the same
+logic can power a REST endpoint, background job, or command line tool.  The
+primary entry point is :func:`generate_ranked_results` which loads stored
+articles, runs the :class:`~backend.analysis.ArticleAnalyzer`, and serialises the
+ranked output as JSON.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+from .analysis import AnalysisSummary, Article, ArticleAnalyzer
+
+
+def load_articles_from_json(path: Path) -> List[Article]:
+    """Load articles from a JSON array stored at *path*.
+
+    The loader accepts either a list of dictionaries (one per article) or a
+    dictionary with an ``"articles"`` key.  Any records that cannot be parsed
+    into an :class:`Article` object are skipped to keep the pipeline resilient to
+    malformed input.
+    """
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if isinstance(payload, dict) and "articles" in payload:
+        records = payload.get("articles", [])
+    else:
+        records = payload
+
+    articles: List[Article] = []
+    if not isinstance(records, Sequence):
+        return articles
+
+    for item in records:
+        if not isinstance(item, dict):
+            continue
+        article = Article.from_dict(item)
+        if not article.content:
+            continue
+        articles.append(article)
+
+    return articles
+
+
+def analyse_articles(articles: Iterable[Article]) -> AnalysisSummary:
+    """Analyse *articles* and return a rich :class:`AnalysisSummary`."""
+
+    analyzer = ArticleAnalyzer()
+    return analyzer.analyze_articles(articles)
+
+
+def generate_ranked_results(path: Path, top_n: int = 10) -> str:
+    """Load articles from *path* and return ranked analysis as formatted JSON."""
+
+    articles = load_articles_from_json(path)
+    summary = analyse_articles(articles)
+    return json.dumps(summary.to_serializable(top_n=top_n), indent=2)
+
+
+def main(default_path: str = "data/articles.json", top_n: int = 10) -> None:
+    """CLI entry point used for manual validation or cron jobs."""
+
+    path = Path(default_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Could not locate article store: {path}")
+
+    print(generate_ranked_results(path, top_n=top_n))
+
+
+if __name__ == "__main__":
+    main()

--- a/data/articles.json
+++ b/data/articles.json
@@ -1,0 +1,45 @@
+[
+  {
+    "id": "art-001",
+    "title": "Apple beats expectations with record iPhone revenue",
+    "content": "Apple $AAPL posted another quarter of record growth as iPhone demand surged. Analysts noted the company beat revenue and earnings forecasts while announcing an ambitious share buyback program.",
+    "tickers": ["AAPL"],
+    "social": {"shares": 1800, "likes": 950, "comments": 230}
+  },
+  {
+    "id": "art-002",
+    "title": "Tesla warns on margins amid aggressive price cuts",
+    "content": "Tesla (TSLA) delivered vehicles above guidance but warned that profit margins will decline after another round of price cuts. The company noted higher regulation costs in Europe and a potential slowdown in China.",
+    "tickers": ["TSLA"],
+    "engagement": {"shares": 900, "retweets": 300, "mentions": 120}
+  },
+  {
+    "id": "art-003",
+    "title": "Microsoft expands AI partnership with OpenAI",
+    "content": "Microsoft announced a new strategic partnership focused on cloud AI growth. The upgrade should accelerate Azure revenue and reflects bullish guidance from executives. Shares of MSFT rallied in after-hours trading.",
+    "tickers": ["MSFT"],
+    "social_shares": 600
+  },
+  {
+    "id": "art-004",
+    "title": "Johnson & Johnson faces lawsuit over talc products",
+    "content": "Johnson & Johnson (JNJ) is facing a new lawsuit alleging product safety issues. Analysts fear the litigation will pressure earnings and could lead to a large settlement. The downgrade follows previous regulatory warnings.",
+    "tickers": ["JNJ"],
+    "social": {"shares": 450, "likes": 120, "comments": 80}
+  },
+  {
+    "id": "art-005",
+    "title": "Amazon sees resilient holiday sales and upbeat guidance",
+    "content": "Amazon $AMZN reported resilient holiday demand with strong growth across its marketplace. Executives highlighted improving profit margins and upgraded guidance for the next quarter while expanding its partnership network.",
+    "tickers": ["AMZN"],
+    "social": {"shares": 1500, "likes": 700, "comments": 210}
+  },
+  {
+    "id": "art-006",
+    "title": "Bank sector watch: Wells Fargo and JPMorgan trading mixed",
+    "content": "Financial stocks were mixed as Wells Fargo WFC issued cautious guidance while JPMorgan $JPM reiterated bullish revenue targets. Analysts suggested watching for regulatory headlines and capital requirements updates.",
+    "tickers": ["WFC"],
+    "social": {"shares": 300, "likes": 140, "comments": 45},
+    "metadata": {"primary_ticker": "WFC"}
+  }
+]


### PR DESCRIPTION
## Summary
- implement a rule-based `ArticleAnalyzer` that scores news for keywords, sentiment, social buzz, and investment actions
- add service helpers that load stored articles, aggregate ticker impact, and emit top ranked JSON output
- include sample article dataset, documentation, and gitignore for cache artifacts

## Testing
- python -m backend.service

------
https://chatgpt.com/codex/tasks/task_e_68cea00ffc188327b5a42f7b5b1fe19b